### PR TITLE
Fixed wrong attribute ID

### DIFF
--- a/Setup/InstallData.php
+++ b/Setup/InstallData.php
@@ -78,8 +78,8 @@ class InstallData implements InstallDataInterface
 
         $eavSetup->addAttributeToGroup(
             \Magento\Catalog\Model\Product::ENTITY,
-            'Default',
-            'General',
+            $eavSetup->getDefaultAttributeSetId(\Magento\Catalog\Model\Product::ENTITY),
+            $eavSetup->getDefaultAttributeGroupId(\Magento\Catalog\Model\Product::ENTITY),
             self::ATTRIBUTE_NAME
         );
     }


### PR DESCRIPTION
Attribute ID "Default" results in error: "The attribute set ID is incorrect. Verify the ID and try again."

-Added the Default Value for "SetId" and "GroupId"