### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "Bestsellers sorting of products in categories for Magento 2.",
     "license": "GPL-3.0",
     "type": "magento2-module",
-    "version": "0.1.0",
     "require": {
         "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0"
     },


### PR DESCRIPTION
This always leads to issues. Currently, Composer will not pick up the new version, because the tagged version does not match the one from `composer.json`.